### PR TITLE
Refactored to take CommandContext instead og SlashCommandContext

### DIFF
--- a/DSharpPlus.BetterPagination/Extensions/DiscordInteractionResponseBuilderExtensions.cs
+++ b/DSharpPlus.BetterPagination/Extensions/DiscordInteractionResponseBuilderExtensions.cs
@@ -1,0 +1,33 @@
+using DSharpPlus.Entities;
+using DSharpPlus.Interactivity;
+
+namespace DSharpPlus.BetterPagination.Extensions;
+
+internal static class DiscordInteractionResponseBuilderExtensions
+{
+    internal static DiscordInteractionResponseBuilder WithPageContent(this DiscordInteractionResponseBuilder builder, Page page)
+    {
+        builder.AddEmbed(page.Embed);
+
+        if (page.Components.Count > 0)
+            builder.AddComponents(page.Components);
+
+        builder.WithContent(page.Content);
+        
+        return builder;
+    }
+
+    internal static DiscordInteractionResponseBuilder WithPaginationArgs(
+        this DiscordInteractionResponseBuilder builder,
+        IReadOnlyList<DiscordComponent>? additionalComponents,
+        bool asEphemeral)
+    {
+        if (asEphemeral)
+            builder.AsEphemeral();
+
+        if (additionalComponents != null)
+            builder.AddComponents(additionalComponents);
+        
+        return builder;
+    }
+}

--- a/DSharpPlus.BetterPagination/Extensions/DiscordMessageBuilderExtensions.cs
+++ b/DSharpPlus.BetterPagination/Extensions/DiscordMessageBuilderExtensions.cs
@@ -1,0 +1,25 @@
+using DSharpPlus.Entities;
+using DSharpPlus.Interactivity;
+
+namespace DSharpPlus.BetterPagination.Extensions;
+
+internal static class DiscordMessageBuilderExtensions
+{
+    internal static DiscordMessageBuilder WithPaginationArgs(
+        this DiscordMessageBuilder builder,
+        Page page,
+        IReadOnlyList<DiscordComponent>? additionalComponents)
+    {
+        builder.AddEmbed(page.Embed);
+
+        if (page.Components.Count > 0)
+            builder.AddComponents(page.Components);
+
+        builder.WithContent(page.Content);
+        
+        if (additionalComponents != null)
+            builder.AddComponents(additionalComponents);
+        
+        return builder;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This package adds an extension method, `SendBetterPaginatedMessageAsync`, to the
 
 ### SendBetterPaginatedMessageAsync Parameters
 
-- `context` (`SlashCommandContext`):  
+- `commandContext` (`SlashCommandContext`):  
   The context of the slash command invocation, containing user information and the interaction context. This is required to send the initial response and track the user interaction.  
   [More info on `SlashCommandContext`](https://dsharpplus.github.io/DSharpPlus/api/DSharpPlus.Commands.Processors.SlashCommands.SlashCommandContext.html)
 
@@ -81,7 +81,7 @@ public async ValueTask PaginatedExampleCommand(SlashCommandContext context)
     List<Page> pages =
     [
         new() { Embed = embedPageOne },
-        new() { Embed = embedPageTwo }
+        new() { Embed = embedPageTwo, Content = "Text content in message" }
     ];
 
     // Send the paginated message


### PR DESCRIPTION
CommandContext makes the library support these two ways of registering slash commands.

```csharp
[Command("slashCommand")]
public static async ValueTask SlashOnlyAsync(SlashCommandContext context) =>
    await context.RespondAsync("This is a slash command");
```

```csharp
[Command("slashCommand"), AllowedProcessors<SlashCommandProcessor>()]
public static async ValueTask SlashOnlyAsync(CommandContext context) =>
    await context.RespondAsync("This is a slash command");
```